### PR TITLE
Fix mobile card component viewport issue

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -27,6 +27,8 @@ const { title, text, imageUrl, link } = Astro.props;
         position: relative;
         background: transparent;
         margin-bottom: var(--spacing-lg);
+        max-width: 100%;
+        overflow-wrap: break-word;
     }
 
     .card-content {
@@ -35,16 +37,33 @@ const { title, text, imageUrl, link } = Astro.props;
         gap: var(--spacing-md);
     }
 
+    .text-content {
+        max-width: 100%;
+        overflow-wrap: break-word;
+    }
+
     .text-content h3 {
         font-size: var(--font-size-xl);
         margin: 0 0 var(--spacing-sm) 0;
         line-height: 1.2;
+        overflow-wrap: break-word;
+        word-break: break-word;
     }
 
     .text-content p {
         font-size: var(--font-size-base);
         margin: 0;
         line-height: 1.6;
+        overflow-wrap: break-word;
+        word-break: break-word;
+        max-width: 100%;
+    }
+
+    /* Handle long URLs and links in text content */
+    .text-content p :global(a) {
+        overflow-wrap: break-word;
+        word-break: break-all;
+        hyphens: auto;
     }
 
     .image-content img {

--- a/src/components/NewsCard.astro
+++ b/src/components/NewsCard.astro
@@ -46,6 +46,8 @@ const { title, text, date, picture, picture_full, picture_alt, post_sub, type, l
     .news-card {
         background: transparent;
         margin-bottom: var(--spacing-lg);
+        max-width: 100%;
+        overflow-wrap: break-word;
     }
     
     .news-content {
@@ -54,22 +56,34 @@ const { title, text, date, picture, picture_full, picture_alt, post_sub, type, l
         gap: var(--spacing-md);
     }
     
+    .text-content {
+        max-width: 100%;
+        overflow-wrap: break-word;
+    }
+    
     .date {
         color: var(--accent-color);
         font-size: var(--font-size-base);
         margin-bottom: var(--spacing-xs);
+        overflow-wrap: break-word;
+        word-break: break-word;
     }
     
     h3 {
         font-size: var(--font-size-xl);
         margin: 0 0 var(--spacing-sm) 0;
         line-height: 1.2;
+        overflow-wrap: break-word;
+        word-break: break-word;
     }
     
     p {
         font-size: var(--font-size-base);
         margin: var(--spacing-xs) 0;
         line-height: 1.6;
+        overflow-wrap: break-word;
+        word-break: break-word;
+        max-width: 100%;
     }
     
     .images-grid {
@@ -122,11 +136,18 @@ const { title, text, date, picture, picture_full, picture_alt, post_sub, type, l
 
     .link-container {
         margin-top: 1rem;
+        max-width: 100%;
+        overflow-wrap: break-word;
     }
 
     .link-container a {
         color: var(--text-color);
         text-decoration: underline;
+        overflow-wrap: break-word;
+        word-break: break-all;
+        hyphens: auto;
+        display: inline-block;
+        max-width: 100%;
     }
 
     .link-container a:hover {


### PR DESCRIPTION
The mobile viewport overflow issue, caused by long, un-breakable strings (e.g., URLs) within card components, was addressed.

Changes were applied to `src/components/Card.astro` and `src/components/NewsCard.astro`:
*   Container elements (`.card`, `.news-card`, `.text-content`, `.link-container`) were given `max-width: 100%` and `overflow-wrap: break-word` to constrain content and allow breaking.
*   Text elements (headings, paragraphs, dates) received `overflow-wrap: break-word` and `word-break: break-word` to ensure general text wrapping.
*   Links within paragraphs in `Card.astro` and within `.link-container a` in `NewsCard.astro` were specifically targeted with `word-break: break-all` and `hyphens: auto` for aggressive breaking of long URLs.
*   Additionally, `.link-container a` in `NewsCard.astro` was set to `display: inline-block` to correctly apply `max-width: 100%` for its container.

These modifications ensure that long strings and URLs now wrap appropriately, preventing horizontal viewport expansion and maintaining the intended mobile layout.