### PR TITLE
Add page counter to news pagination

### DIFF
--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -69,6 +69,7 @@ const currentNews = sortedNewsData.slice(pagination.startIndex, pagination.endIn
 			currentPage={pagination.currentPage}
 			totalPages={pagination.totalPages}
 			basePath="/news"
+			showPageInfo={true}
 		/>
 	</section>
 </Layout>


### PR DESCRIPTION
A page counter indicator was added to the news pagination to match the visuals pagination.

*   The `Pagination` component in `src/pages/news.astro` was updated to include the `showPageInfo={true}` prop.
*   This change enables the display of "Page X of Y" information on the news pagination.
*   The codebase already utilizes a shared `Pagination` component (`src/components/Pagination.astro`) and pagination utilities (`src/utils/pagination.ts`), confirming that DRY principles were already well-implemented.
*   The modification ensures consistent pagination behavior across both news and visuals sections, with both now displaying the total page count.